### PR TITLE
Update sentry-onpremise-quickstart-template.yaml

### DIFF
--- a/openshift/sentry-onpremise-quickstart-template.yaml
+++ b/openshift/sentry-onpremise-quickstart-template.yaml
@@ -1966,6 +1966,7 @@ objects:
               volumeMounts:
                 - mountPath: /var/lib/postgresql/data
                   name: sentry-postgres
+                  subPath: pgdata
           restartPolicy: Always
           serviceAccountName: "${SERVICE_ACCOUNT_NAME}"
           volumes:


### PR DESCRIPTION
This fixes postgresql initdb runs, as it has a lost+found directory in the mountpoint it complains about. 